### PR TITLE
linqへの依存を無くす対応

### DIFF
--- a/game.json
+++ b/game.json
@@ -229,11 +229,9 @@
 		"node_modules/@akashic-extension/akashic-timeline/lib/Easing.js",
 		"node_modules/@akashic-extension/akashic-timeline/lib/Timeline.js",
 		"node_modules/@akashic-extension/akashic-timeline/lib/Tween.js",
-		"node_modules/@akashic-extension/akashic-timeline/lib/index.js",
-		"node_modules/linq/linq.js"
+		"node_modules/@akashic-extension/akashic-timeline/lib/index.js"
 	],
 	"moduleMainScripts": {
-		"@akashic-extension/akashic-timeline": "node_modules/@akashic-extension/akashic-timeline/lib/index.js",
-		"linq": "node_modules/linq/linq"
+		"@akashic-extension/akashic-timeline": "node_modules/@akashic-extension/akashic-timeline/lib/index.js"
 	}
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2817,11 +2817,6 @@
         "astw": "^2.0.0"
       }
     },
-    "linq": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/linq/-/linq-3.1.1.tgz",
-      "integrity": "sha512-A71Vnqe93xFkYYTuTzne1dQ+tVzXwYRrgZE3koGbXVd+3Ie5IiBgCpaFTnG+XkaSW/vPmsFAt2rG4znmJAxKlw=="
-    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "typescript": "~2.6.2"
   },
   "dependencies": {
-    "@akashic-extension/akashic-timeline": "^2.1.0",
-    "linq": "^3.1.1"
+    "@akashic-extension/akashic-timeline": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/FieldScene.ts
+++ b/src/FieldScene.ts
@@ -1,5 +1,4 @@
 import * as tl from "@akashic-extension/akashic-timeline";
-import * as Enumerable from "linq/linq";
 import { GameTimer } from "./GameTimer";
 import { Global } from "./Global";
 import { AudioPresenter } from "./AudioPresenter";
@@ -325,7 +324,7 @@ export class FieldScene extends AStage {
 
 	private getPictureNumber(): number {
 		if (this.pictureNumberTable.length < 1) {
-			this.pictureNumberTable = Util.shuffle(Enumerable.range(0, 5).toArray());
+			this.pictureNumberTable = Util.shuffle(Util.range(0, 5));
 			if (this.pictureNumberTable[0] === this.lastSelectPictureNumber) {
 				const n = this.pictureNumberTable[0];
 				this.pictureNumberTable[0] = 5;

--- a/src/GameField.ts
+++ b/src/GameField.ts
@@ -1,4 +1,3 @@
-import * as Enumerable from "linq/linq";
 import { SpriteFactory } from "./SpriteFactory";
 import { Global } from "./Global";
 import { Util } from "./Util";

--- a/src/Picture.ts
+++ b/src/Picture.ts
@@ -1,4 +1,3 @@
-import * as Enumerable from "linq/linq";
 import { SpriteFactory } from "./SpriteFactory";
 import { PieceSize } from "./PieceSelectField";
 import { Global } from "./Global";
@@ -89,8 +88,8 @@ export class Picture extends g.E {
 			}
 		}
 
-		const ctbl: number[] = Enumerable.repeat(0, dtbl.length).toArray();
-		Util.shuffle(Enumerable.range(0, dtbl.length).toArray()).forEach((idx) => {
+		const ctbl: number[] = Util.repeat(0, dtbl.length);
+		Util.shuffle(Util.range(0, dtbl.length)).forEach((idx) => {
 			const neigbars = this.getPiecesNeighborsIndex(idx, divX, divY);
 			let depress = dtbl[idx];
 			let convex = 0;

--- a/src/PieceSelectField.ts
+++ b/src/PieceSelectField.ts
@@ -1,4 +1,3 @@
-import * as Enumerable from "linq/linq";
 import { Timeline } from "@akashic-extension/akashic-timeline";
 import { easeInCubic, easeOutQuart } from "@akashic-extension/akashic-timeline/lib/Easing";
 import { SpriteFactory } from "./SpriteFactory";
@@ -53,7 +52,7 @@ export class PieceSelectField extends g.E {
 		super({ scene: s });
 
 		// 出す順番
-		this.indexTable = Util.shuffle(Enumerable.range(0, pieces.length).toArray());
+		this.indexTable = Util.shuffle(Util.range(0, pieces.length));
 		this.pieceTable = pieces;
 
 		this.pieceLayer = new g.E({ scene: s });

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -51,4 +51,19 @@ export class Util {
 		return {x: ofs.x, y: ofs.y, width: r.width, height: r.height};
 	}
 
+	static range(start: number, count: number, step: number = 1): number[] {
+		const result: number[] = [];
+		for (let i = 0; i < count; i++) {
+			result.push(start + i * step);
+		}
+		return result;
+	}
+
+	static repeat<T>(obj: T, count: number): T[] {
+		const result: T[] = [];
+		for (let i = 0; i < count; i++) {
+			result.push(obj);
+		}
+		return result;
+	}
 }


### PR DESCRIPTION
### やったこと
* linqを`akashic uninstall`した
* linqのEnumerable.rangeやEnumerable.repeatの代用としてUtil.rangeとUtil.repeatを新たに作成
  * rangeとrepeatの仕様やシグニチャはlinq.jsのRANGEやREPEATに準拠した形にしました。( http://neue.cc/reference.htm )